### PR TITLE
Updating csvw-check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Scala
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
           cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+
       - name: Show output of sed to build.sbt command for logs
         run: |
           VERS_TAG=$(echo $GIT_REF | sed 's/refs\/tags\/v//g')
           VERS_TAG="\"$VERS_TAG"\"
           sed "s/version := *.*/version := $VERS_TAG/" build.sbt
+
       - name: Write Tag to Scala Build Version
         run: |
           VERS_TAG=$(echo $GIT_REF | sed 's/refs\/tags\/v//g')
@@ -44,11 +49,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Submit SBT dependencies to the GitHub dependency graph.
+      - name: Sbt Dependency Submission
+        uses: scalacenter/sbt-dependency-submission@v3.1.0
+
       - name: Build Universal Artifact
         run: sbt Universal/packageBin
 
       - name: Archive package and documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: csvw-check-universal
           path: target/universal/csvw-check-*.zip
@@ -68,7 +77,7 @@ jobs:
           rel_cand_substring='rc'
           vers_num_lower_case=${vers_num,,}
 
-          local_param="csvwcheck:$vers_num"
+          local_param="csvw-check:$vers_num"
           remote_param="gsscogs/csvw-check"
           push_param="$remote_param:v$vers_num"
           latest_param="$remote_param:latest"

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -10,7 +10,7 @@ jobs:
   test_in_environments:
     runs-on: ${{ inputs.os }}
     container:
-      image: sbtscala/scala-sbt:graalvm-ce-22.3.0-b2-java17_1.8.3_2.13.10
+      image: sbtscala/scala-sbt:graalvm-ce-22.3.3-b1-java17_1.10.7_3.6.3
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,7 +24,7 @@ jobs:
 
       - name: Archive test results from xml files
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.os }} test results
           path: |
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.os }} test results
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,43 +1,48 @@
+import com.typesafe.sbt.packager.docker.Cmd
+
 name := "csvw-check"
 
 organization := "io.github.gss-cogs"
 version := "0.0.3"
 maintainer := "csvcubed@gsscogs.uk"
 
-scalaVersion := "2.13.4"
+scalaVersion := "2.13.16"
 scalacOptions ++= Seq("-deprecation", "-feature")
 autoCompilerPlugins := true
 
 enablePlugins(JavaAppPackaging)
-enablePlugins(DockerPlugin)
 enablePlugins(UniversalPlugin)
+enablePlugins(DockerPlugin)
+enablePlugins(AshScriptPlugin)
 
-dockerBaseImage := "openjdk:11"
-dockerEntrypoint := Seq("bash")
+dockerBaseImage := "eclipse-temurin:23-jre-alpine"
+dockerEntrypoint := Seq("/opt/docker/bin/csvw-check")
 dockerEnvVars := Map("PATH" -> "$PATH:/opt/docker/bin")
-Docker / packageName := "csvwcheck"
+Docker / packageName := "csvw-check"
 
-libraryDependencies += "io.cucumber" %% "cucumber-scala" % "8.14.1" % Test
-libraryDependencies += "io.cucumber" % "cucumber-junit" % "7.11.1" % Test
+libraryDependencies += "io.cucumber" %% "cucumber-scala" % "8.26.1" % Test
+libraryDependencies += "io.cucumber" % "cucumber-junit" % "7.21.1" % Test
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
 libraryDependencies += "com.github.pathikrit" %% "better-files" % "3.9.2" % Test
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
 libraryDependencies += "io.spray" %% "spray-json" % "1.3.6"
-libraryDependencies += "org.apache.jena" % "jena-arq" % "4.4.0"
-libraryDependencies += "joda-time" % "joda-time" % "2.12.2"
+libraryDependencies += "org.apache.jena" % "jena-arq" % "5.3.0"
+libraryDependencies += "joda-time" % "joda-time" % "2.13.1"
 libraryDependencies += "com.github.scopt" %% "scopt" % "4.1.0"
+// Past version 2.6.21 AKKA starts requiring a license key which doesn't fit the use-case of this OSS project at all.
+// Unfortunately it looks like we will want to stop using AKKA entirely, which would require quite a bit of work.
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.21"
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.3"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.16"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2"
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-annotations" % "2.14.2"
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.14.2"
-libraryDependencies += "com.softwaremill.sttp.client3" %% "core" % "3.8.15"
-libraryDependencies += "com.ibm.icu" % "icu4j" % "72.1"
-libraryDependencies += "org.apache.commons" % "commons-csv" % "1.10.0"
-libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.10"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.2"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-annotations" % "2.18.2"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.18.2"
+libraryDependencies += "com.softwaremill.sttp.client3" %% "core" % "3.10.3"
+libraryDependencies += "com.ibm.icu" % "icu4j" % "76.1"
+libraryDependencies += "org.apache.commons" % "commons-csv" % "1.13.0"
+libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.12"
 
 publishTo := Some("GitHub Maven package repo for GSS-Cogs" at "https://maven.pkg.github.com/gss-cogs/csvw-check")
 publishMavenStyle := true
@@ -50,4 +55,4 @@ credentials += Credentials(
 
 organizationName := "Crown Copyright (Office for National Statistics)"
 startYear := Some(2020)
-licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+licenses += ("Apache-2.0", new URI("https://www.apache.org/licenses/LICENSE-2.0.txt").toURL)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.10.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.1.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")

--- a/src/main/scala/csvwcheck/ConfiguredObjectMapper.scala
+++ b/src/main/scala/csvwcheck/ConfiguredObjectMapper.scala
@@ -16,14 +16,19 @@
 
 package csvwcheck
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 
 object ConfiguredObjectMapper {
   val objectMapper = new ObjectMapper()
-  objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true))
+
   objectMapper.configure(
-    DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS,
+    JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES,
     true
+  )
+
+  objectMapper.configure(
+      DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS,
+  true
   )
 }

--- a/src/main/scala/csvwcheck/Validator.scala
+++ b/src/main/scala/csvwcheck/Validator.scala
@@ -53,10 +53,8 @@ class Validator(
           val metadataJsonLocation =
             csvwLinkHeaderRegEx.replaceAllIn(header, "$1")
           // Now make the URL absolute if it isn't already.
-          new URL(
-            new URL(getUriWithoutQueryString(csvUri).toString),
-            metadataJsonLocation
-          ).toURI
+          getUriWithoutQueryString(csvUri)
+            .resolve(metadataJsonLocation)
         })
     } else {
       None

--- a/src/main/scala/csvwcheck/errors/MessageWithCsvContext.scala
+++ b/src/main/scala/csvwcheck/errors/MessageWithCsvContext.scala
@@ -31,6 +31,8 @@ abstract class MessageWithCsvContext {
   def content: String
 
   def constraints: String
+
+  def csvFilePath: Option[String]
 }
 
 case class ErrorWithCsvContext(
@@ -39,7 +41,8 @@ case class ErrorWithCsvContext(
                                 row: String,
                                 column: String,
                                 content: String,
-                                constraints: String
+                                constraints: String,
+                                csvFilePath: Option[String] = None
                               ) extends MessageWithCsvContext {}
 
 case class WarningWithCsvContext(
@@ -48,5 +51,6 @@ case class WarningWithCsvContext(
                                   row: String,
                                   column: String,
                                   content: String,
-                                  constraints: String
+                                  constraints: String,
+                                  csvFilePath: Option[String] = None
                                 ) extends MessageWithCsvContext {}

--- a/src/main/scala/csvwcheck/models/ForeignKeyDefinition.scala
+++ b/src/main/scala/csvwcheck/models/ForeignKeyDefinition.scala
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 case class ForeignKeyDefinition(
                                  jsonObject: ObjectNode,
                                  localColumns: Array[Column]
-                               ) {
+                               ) extends Key {
   override def toString: String =
     s"ForeignKeyDefinition([${localColumns.map(_.name.getOrElse("unnamed column")).mkString(", ")}])"
 

--- a/src/main/scala/csvwcheck/models/Key.scala
+++ b/src/main/scala/csvwcheck/models/Key.scala
@@ -1,0 +1,8 @@
+package csvwcheck.models
+
+/**
+ * Represents a primary or foreign key.
+ */
+abstract class Key {
+
+}

--- a/src/main/scala/csvwcheck/models/KeyValueWithContext.scala
+++ b/src/main/scala/csvwcheck/models/KeyValueWithContext.scala
@@ -16,10 +16,12 @@
 
 package csvwcheck.models
 
-case class KeyWithContext(
-                           rowNumber: Long,
-                           keyValues: List[Any],
-                           var isDuplicate: Boolean = false
+import csvwcheck.models.Values.KeyValue
+
+case class KeyValueWithContext(
+                                rowNumber: Long,
+                                keyValue: KeyValue,
+                                var isDuplicate: Boolean = false
                          ) {
 
   /**
@@ -29,13 +31,13 @@ case class KeyWithContext(
     */
   override def equals(obj: Any): Boolean =
     obj != null &&
-      obj.isInstanceOf[KeyWithContext] &&
-      this.keyValues.equals(obj.asInstanceOf[KeyWithContext].keyValues)
+      obj.isInstanceOf[KeyValueWithContext] &&
+      this.keyValue.equals(obj.asInstanceOf[KeyValueWithContext].keyValue)
 
-  override def hashCode(): Int = this.keyValues.hashCode()
+  override def hashCode(): Int = this.keyValue.hashCode()
 
   def keyValuesToString(): String = {
-    val stringList = keyValues.map {
+    val stringList = keyValue.map {
       case listOfAny: List[Any] =>
         listOfAny.map(s => s.toString).mkString(",")
       case i => i.toString

--- a/src/main/scala/csvwcheck/models/ReferencedTableForeignKeyReference.scala
+++ b/src/main/scala/csvwcheck/models/ReferencedTableForeignKeyReference.scala
@@ -29,7 +29,7 @@ case class ReferencedTableForeignKeyReference(
                                                  * The table the foreign key was defined on.
                                                  */
                                                definitionTable: Table
-                                             ) {
+                                             ) extends Key {
   override def toString: String =
     s"ReferencedTableForeignKeyReference($definitionTable.[${
       foreignKeyDefinition.localColumns

--- a/src/main/scala/csvwcheck/models/TableSchema.scala
+++ b/src/main/scala/csvwcheck/models/TableSchema.scala
@@ -261,11 +261,18 @@ object TableSchema {
           val columnReference = columnReferenceElementTextNode.asText
           columns
             .find(col => col.name.contains(columnReference))
-            .map(Right(_))
+            .map(col => {
+              if (col.separator.isEmpty) {
+                Right(col)
+              } else {
+                // Code reference: 7da26b34-efa5-11ef-8180-57883ec4256f
+                Left(MetadataError(s"foreign key references list column '$columnReference'; behaviour is undefined"))
+              }
+            })
             .getOrElse(
               Left(
                 MetadataError(
-                  s"foreignKey references non-existent column - $columnReference"
+                  s"foreignKey references non-existent column '$columnReference'"
                 )
               )
             )

--- a/src/main/scala/csvwcheck/models/ValidateRowOutput.scala
+++ b/src/main/scala/csvwcheck/models/ValidateRowOutput.scala
@@ -16,13 +16,15 @@
 
 package csvwcheck.models
 
+import csvwcheck.models.Values.KeyValue
+
 case class ValidateRowOutput(
                               recordNumber: Long,
                               warningsAndErrors: WarningsAndErrors = WarningsAndErrors(),
-                              primaryKeyValues: List[Any] = List(),
+                              primaryKeyValue: KeyValue = List(),
                               parentTableForeignKeyReferences: Map[
                                 ReferencedTableForeignKeyReference,
-                                KeyWithContext
+                                KeyValueWithContext
                               ] = Map(),
-                              childTableForeignKeys: Map[ForeignKeyDefinition, KeyWithContext] = Map()
+                              childTableForeignKeys: Map[ForeignKeyDefinition, KeyValueWithContext] = Map()
                             )

--- a/src/main/scala/csvwcheck/models/Values.scala
+++ b/src/main/scala/csvwcheck/models/Values.scala
@@ -1,0 +1,21 @@
+package csvwcheck.models
+
+object Values {
+  /**
+   * Part of a KeyValue. Whereas a KeyValue may take values from multiple columns, a KeyComponent value is from
+   * a single column.
+   */
+  type KeyComponentValue = Any
+
+  /**
+   * The value associated with a Key in a given row.
+   */
+  type KeyValue = List[KeyComponentValue]
+
+  /**
+   * Represents the value from one particular column.
+   *
+   * May contain multiple values if the column represents a list (i.e. has a separator set).
+   */
+  type ColumnValue = List[Any]
+}

--- a/src/main/scala/csvwcheck/normalisation/Utils.scala
+++ b/src/main/scala/csvwcheck/normalisation/Utils.scala
@@ -575,11 +575,13 @@ object Utils {
       .map((_, noWarnings, csvwPropertyType))
   }
 
-  def toAbsoluteUrl(possiblyRelativeUrl: String, baseUrl: String): String =
+  private def toAbsoluteUrl(possiblyRelativeUrl: String, baseUrl: String): String =
     if (baseUrl.isEmpty) {
       possiblyRelativeUrl
     } else {
-      new URL(new URL(baseUrl), possiblyRelativeUrl).toString
+      new URI(baseUrl)
+        .resolve(possiblyRelativeUrl)
+        .toString
     }
 
   def normaliseNaturalLanguageProperty(

--- a/src/test/resources/csvwExamples/foreign-key-with-separator.csv
+++ b/src/test/resources/csvwExamples/foreign-key-with-separator.csv
@@ -1,0 +1,3 @@
+countryRefs,info
+EU|UK,The European Union and the UK
+UK|EU|UK,The European Union and the UK and then the EU again

--- a/src/test/resources/csvwExamples/foreign-key-with-separator.csv-metadata.json
+++ b/src/test/resources/csvwExamples/foreign-key-with-separator.csv-metadata.json
@@ -1,0 +1,62 @@
+{
+  "@context": "http://www.w3.org/ns/csvw",
+  "tables": [
+    {
+      "url": "countries.csv",
+      "tableSchema": {
+        "columns": [
+          {
+            "name": "countryCode",
+            "titles": "countryCode",
+            "datatype": "string",
+            "propertyUrl": "http://www.geonames.org/ontology{#_name}"
+          },
+          {
+            "name": "latitude",
+            "titles": "latitude",
+            "datatype": "number"
+          },
+          {
+            "name": "longitude",
+            "titles": "longitude",
+            "datatype": "number"
+          },
+          {
+            "name": "name",
+            "titles": "name",
+            "datatype": "string"
+          }
+        ],
+        "aboutUrl": "http://example.org/countries.csv{#countryCode}",
+        "propertyUrl": "http://schema.org/{_name}",
+        "primaryKey": "countryCode"
+      }
+    },
+    {
+      "url": "foreign-key-with-separator.csv",
+      "tableSchema": {
+        "columns": [
+          {
+            "name": "countryRefs",
+            "titles": "countryRefs",
+            "separator": "|",
+            "ordered": false
+          },
+          {
+            "name": "info",
+            "titles": "info"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "columnReference": "countryRefs",
+            "reference": {
+              "resource": "countries.csv",
+              "columnReference": "countryCode"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/scala/csvwcheck/TestUtils.scala
+++ b/src/test/scala/csvwcheck/TestUtils.scala
@@ -1,0 +1,21 @@
+package csvwcheck
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Sink
+import csvwcheck.models.WarningsAndErrors
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+object TestUtils {
+  implicit final val system: ActorSystem = ActorSystem("actor-system")
+
+  def RunValidationInAkka(validator: Validator): WarningsAndErrors = {
+    var warningsAndErrors = WarningsAndErrors()
+    val akkaStream =
+      validator.validate().map(wAndE => warningsAndErrors = wAndE)
+    Await.ready(akkaStream.runWith(Sink.ignore), 10.hours)
+
+    warningsAndErrors
+  }
+}

--- a/src/test/scala/csvwcheck/bugs/ForeignKeys.scala
+++ b/src/test/scala/csvwcheck/bugs/ForeignKeys.scala
@@ -1,0 +1,23 @@
+package csvwcheck.bugs
+
+import csvwcheck.TestPaths.resourcesPath
+import csvwcheck.TestUtils.RunValidationInAkka
+import csvwcheck.Validator
+import org.scalatest.funsuite.AnyFunSuite
+
+class ForeignKeys extends AnyFunSuite {
+
+  test("A foreign key definition referencing a list column should return an error") {
+    // Code reference 7da26b34-efa5-11ef-8180-57883ec4256f
+    val csvwInput = resourcesPath./("csvwExamples")./("foreign-key-with-separator.csv-metadata.json")
+    val validator = new Validator(Some(csvwInput.path.toString))
+    val warningsAndErrors = RunValidationInAkka(validator)
+
+    assert(warningsAndErrors.warnings.isEmpty)
+    assert(warningsAndErrors.errors.length == 1)
+    val error = warningsAndErrors.errors.head
+
+    assert(error.`type` == "metadata")
+    assert(error.content.contains("foreign key references list column"))
+  }
+}


### PR DESCRIPTION
To anyone who is watching this repository, note that I have made some changes in a fork of the csvw-check repository to make it build again and update some of the dependencies.

I have: 

- Updated dependencies where reasonably possible.
- Added error when a foreign key references a list column (See https://github.com/w3c/csvw/issues/899).
- Ensured that AKKA responds to the desired log level.
- Begin to distinguish between the value in a column (which may have multiple values therein) and a value which is part of a key.

If for some reason you don't wish to merge this in and create a new release, then please leave this PR publicly visible for anyone else who may wish to use csvw-check.

An update docker container exists at https://hub.docker.com/repository/docker/roblinksdata/csvw-check or with `docker pull roblinksdata/csvw-check:v0.3.1`. The universal binary is available [here](https://github.com/roblinksdata/csvw-check/releases/tag/v0.3.1), and a [jar file](https://github.com/roblinksdata/csvw-check/packages/2411897) is also available.